### PR TITLE
fix: taskに対するテストを追加

### DIFF
--- a/1
+++ b/1
@@ -3,6 +3,6 @@
 class Task < ApplicationRecord
   belongs_to :user
 
-  validates :url, presence: true, length: { maximum: 255 }
+  validates :url, presence: true, length: { maximun: 255 }
   validates :status, presence: true, numericality: true
 end

--- a/db/migrate/20210712044649_add_maxminulength_to_task_url.rb
+++ b/db/migrate/20210712044649_add_maxminulength_to_task_url.rb
@@ -1,0 +1,9 @@
+class AddMaxminulengthToTaskUrl < ActiveRecord::Migration[6.0]
+  def up
+    change_column :tasks, :url, :string, limit: 255, null: false
+  end
+
+  def down
+    change_column :tasks, :url, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_12_021657) do
+ActiveRecord::Schema.define(version: 2021_07_12_044649) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "url", null: false

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :task do
-    
+    url { "https://example/test/data/sample_url/" }
+    status { 0 }   
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    @user = FactoryBot.create(:user)
+  end
+
+  context "validi value" do
+    it "is valid with a url, user_id and status" do
+      task = FactoryBot.build(:task, user_id: @user.id)
+      expect(task).to be_valid
+    end
+
+    it "is valid with a url which length is less than 256" do
+      task = FactoryBot.build(:task, user_id: @user.id, url: "a" * 255)
+      expect(task).to be_valid
+    end
+  end
+
+  context "invalid value" do
+    it "is invalid without a url" do
+      task = FactoryBot.build(:task, url: nil)
+      task.valid?
+      expect(task.errors[:url]).to include("can't be blank")
+    end
+
+    it "is invalid without a user_id" do
+      task = FactoryBot.build(:task, user_id: nil)
+      task.valid?
+      expect(task.errors[:user]).to include("must exist")
+    end
+
+    it "is invalid with a url which length is more than 255" do
+      task = FactoryBot.build(:task, user_id: @user.id, url: "a" * 256)
+      task.valid?
+      expect(task.errors[:url]).to include("is too long (maximum is 255 characters)")
+    end
+
+    it "is invalid with a status which is not number" do
+      task = FactoryBot.build(:task, status: "char")
+      task.valid?
+      expect(task.errors[:status]).to include("is not a number")
+    end
+  end
 end


### PR DESCRIPTION
・taskテーブルのurlに長さ制約を追加(255文字まで)
・statusにnumericality制約を追加