### PR TITLE
Ticket32

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,12 @@ Style/StringLiterals:
 
 Style/SymbolArray:
     Enabled: false
+
+Style/WordArray:
+    Enabled: false
+
+Metrics/BlockLength:
+    Max: 100
+
+Layout/LineLength:
+    Max: 140

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -49,10 +49,11 @@ class TasksController < ApplicationController
   end
 
   def update
-    task = Task.find(params[:id])
+    task = Task.find(task_params[:id])
+    task.pre_updated_at = task.updated_at
 
-    if task.update(status: params[:status])
-      render json: { message: '更新完了しました。' }, status: 201
+    if task.update(status: task_params[:status])
+      render json: { message: '更新完了しました。' }, status: 200
     else
       render json: { message: '登録に失敗しました。' }, status: 400
     end
@@ -61,6 +62,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:url, :status)
+    params.require(:task).permit(:id, :url, :status)
   end
 end

--- a/app/javascript/packs/application.css
+++ b/app/javascript/packs/application.css
@@ -30,7 +30,7 @@
 		display: flex;
 		justify-content: space-around;
 	}
-	.task-group-one-week, .task-group-one-month, .task-group-half-a-year, .task-group-today-ac {
+	.task-group-one-week, .task-group-one-month, .task-group-half-a-year, .task-group-today-ac, .task-group-today-registration {
 		color: white;
 		font-size: 20px;
 		background-color: rgb(101, 101, 101, 0.9);
@@ -46,7 +46,7 @@
 		border-top-left-radius: 5%;
 		border-bottom-left-radius: 5%;
 	}	
-	.task-group-today-ac {
+	.task-group-today-registration {
 		border-right: 1px solid black;
 		border-top-right-radius: 5%;
 		border-bottom-right-radius: 5%;
@@ -88,7 +88,7 @@
                 display: flex;
                 justify-content: space-around;
         }
-        .task-group-one-week, .task-group-one-month, .task-group-half-a-year, .task-group-today-ac {
+        .task-group-one-week, .task-group-one-month, .task-group-half-a-year, .task-group-today-ac, .task-group-today-registration {
                 color: white;
                 font-size: 20px;
                 background-color: rgb(101, 101, 101, 0.9);
@@ -104,7 +104,7 @@
                 border-top-left-radius: 5%;
                 border-bottom-left-radius: 5%;
         }
-        .task-group-today-ac {
+        .task-group-today-registration {
                 border-right: 1px solid black;
                 border-top-right-radius: 5%;
                 border-bottom-right-radius: 5%;
@@ -147,7 +147,7 @@
 		flex-direction: column;
 		justify-content: space-around;
         }
-        .task-group-one-week, .task-group-one-month, .task-group-half-a-year, .task-group-today-ac {
+        .task-group-one-week, .task-group-one-month, .task-group-half-a-year, .task-group-today-ac, .task-group-today-registration {
                 color: white;
                 font-size: 20px;
                 background-color: rgb(101, 101, 101, 0.9);
@@ -161,7 +161,7 @@
                 border-top-left-radius: 5%;
                 border-bottom-left-radius: 5%;
         }
-        .task-group-today-ac {
+        .task-group-today-registration {
                 border-right: 1px solid black;
                 border-top-right-radius: 5%;
                 border-bottom-right-radius: 5%;

--- a/app/javascript/packs/user_vue.js
+++ b/app/javascript/packs/user_vue.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   new Vue({
     el: '#app',
     data: {
-        show_component: [true, false, false, false]
+        show_component: [true, false, false, false, false, false]
     },
     methods: {
 	    switchComponent: function(index) {

--- a/app/javascript/src/table_component.vue
+++ b/app/javascript/src/table_component.vue
@@ -4,7 +4,11 @@
         <tr v-for="(task, index) in tasks" :key="task.id" :class="'tasks-table-tr-' + (index % 2 == 0 ? 'even' : 'odd')">
         <td class="tasks-table-td tasks-table-td-index">{{ index + 1}}</td>
         <td class="tasks-table-td"><a :href="task.url">{{  task.url }}</a></a></td>
-        <td class="tasks-table-td tasks-table-td-button"><button class="tasks-table-button" @click="update_task(task)">AC</button></td>
+        <td class="tasks-table-td tasks-table-td-button">
+            <button v-if="type == 0" class="tasks-table-button" @click="update_task(task)">AC</button>
+            <button v-else-if="type == 1" class="tasks-table-button" @click="update_task(task)">戻す</button>
+            <button v-else-if="type == 2" class="tasks-table-button" @click="update_task(task)">削除</button>
+        </td>
         </tr>
     </table>
 </template>
@@ -15,6 +19,7 @@ export default {
         solved_status: Number,
         from_x_days_ago: Number,
         to_y_days_ago: Number,
+        type: Number,
     },
     data: function() {
         return {

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,21 +10,26 @@
             <button @click="switchComponent(0)">one week</button>
           </div>
           <div class="task-group-one-month" :class="{'selected-task-group': show_component[1] }">
-            <button @click="switchComponent(1)">one mont</button>
+            <button @click="switchComponent(1)">one month</button>
           </div>
           <div class="task-group-half-a-year" :class="{'selected-task-group': show_component[2] }">
             <button @click="switchComponent(2)">half a year</button>
           </div>
           <div class="task-group-today-ac" :class="{'selected-task-group': show_component[3] }">
-            <button>today AC</button>
+            <button @click="switchComponent(3)">today AC</button>
+          </div>
+          <div class="task-group-today-registration" :class="{'selected-task-group': show_component[4] }">
+            <button @click="switchComponent(4)">today registared</button>
           </div>
         </div>
         <confirm-url-component></confirm-url-component> 
         <div>
-          <table-component key="one~week" v-if="show_component[0]" :solved_status="0" :from_x_days_ago="20" :to_y_days_ago="0"></table-component>
-          <table-component key="one-month" v-else-if="show_component[1]" :solved_status="1" :from_x_days_ago="40" :to_y_days_ago="30"></table-component>
-          <table-component key="half-a-year" v-else-if="show_component[2]" :solved_status="2" :from_x_days_ago="200" :to_y_days_ago="180"></table-component>
-          </div>
+          <table-component key="one~week" v-if="show_component[0]" :solved_status="0" :from_x_days_ago="8" :to_y_days_ago="7" :type="0"></table-component>
+          <table-component key="one-month" v-else-if="show_component[1]" :solved_status="1" :from_x_days_ago="40" :to_y_days_ago="30" :type="0"></table-component>
+          <table-component key="half-a-year" v-else-if="show_component[2]" :solved_status="2" :from_x_days_ago="200" :to_y_days_ago="180" :type="0"></table-component>
+          <table-component key="today-ac" v-else-if="show_component[3]" :solved_status="[1, 2, 3]" :from_x_days_ago="0" :to_y_days_ago="0" :type="1"></table-component>
+          <table-component key="today-registared" v-else-if="show_component[4]" :solved_status="0" :from_x_days_ago="0" :to_y_days_ago="0" :type="2"></table-component>
+        </div>
       </div>
     </body>
 </html>

--- a/db/migrate/20210729134114_add_pre_update_at_to_task.rb
+++ b/db/migrate/20210729134114_add_pre_update_at_to_task.rb
@@ -1,0 +1,9 @@
+class AddPreUpdateAtToTask < ActiveRecord::Migration[6.0]
+  def up
+    add_column :tasks, :pre_updated_at, :datetime, precision: 6
+  end
+
+  def down
+    remove_column :tasks, :pre_updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_20_083339) do
+ActiveRecord::Schema.define(version: 2021_07_29_134114) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "url", null: false
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2021_07_20_083339) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
     t.integer "status", default: 0, null: false
+    t.datetime "pre_updated_at", precision: 6
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
@@ -27,7 +28,7 @@ ActiveRecord::Schema.define(version: 2021_07_20_083339) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "provider", null: false
     t.string "uid", null: false
-    t.index %w[provider uid], name: "index_users_on_provider_and_uid", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
 end


### PR DESCRIPTION
今後、ACしたタスクを取り消す処理を追加する。
その為に、更新以前のupdated_at値を保持している必要があるので、taskテーブルにpre_updated_atカラムを追加した。
AC押下での更新処理で、対象タスクのupdated_at値をpre_updated_atに代入する。